### PR TITLE
Coping with null FFI Pointers in JRuby. 

### DIFF
--- a/lib/rdf/rdfxml/reader.rb
+++ b/lib/rdf/rdfxml/reader.rb
@@ -59,7 +59,11 @@ module RDF::RDFXML
       # Extract Evaluation Context from an element
       def extract_from_element(el, &cb)
         b = el.attribute_with_ns("base", RDF::XML.to_s)
+        b = nil if b.respond_to?(:null?) && b.null? # to ensure FFI Pointer compatibility
+        
         lang = el.attribute_with_ns("lang", RDF::XML.to_s)
+        lang = nil if lang.respond_to?(:null?) && lang.null? # to make FFI Pointer compatibility
+        
         self.base = self.base.join(b) if b
         self.language = lang if lang
         self.uri_mappings.merge!(extract_mappings(el, &cb))


### PR DESCRIPTION
This patch allows the rdfxml library to deal with nil values that are returned as Null Pointers from FFI when running on JRuby (tested with version 1.5.2).

All the specs should continue to run correctly. I created a Gem that reflects the change here:
https://rubygems.org/gems/the-experimenters-rdf-rdfxml.

Thanks for a helpful gem!

Cheers,
Abdel
