### PR TITLE
Added :stylesheet option to RDF::RDFXML::Writer

### DIFF
--- a/lib/rdf/rdfxml/writer.rb
+++ b/lib/rdf/rdfxml/writer.rb
@@ -132,6 +132,7 @@ module RDF::RDFXML
       @base_uri = @options[:base_uri]
       @lang = @options[:lang]
       @attributes = @options[:attributes] || :none
+      @stylesheet = @options[:stylesheet]
       @debug = @options[:debug]
       raise RDF::WriterError, "Invalid attribute option '#{@attributes}', should be one of #{VALID_ATTRIBUTES.to_sentence}" unless VALID_ATTRIBUTES.include?(@attributes.to_sym)
       self.reset
@@ -151,6 +152,14 @@ module RDF::RDFXML
       doc.root = Nokogiri::XML::Element.new("rdf:RDF", doc)
       doc.root["xml:lang"] = @lang if @lang
       doc.root["xml:base"] = base_uri if base_uri
+
+      if @stylesheet
+        pi = Nokogiri::XML::ProcessingInstruction.new(
+          doc, "xml-stylesheet",
+          "type=\"text/xsl\" href=\"#{@stylesheet}\""
+        )
+        doc.root.add_previous_sibling pi
+      end
       
       # Add statements for each subject
       order_subjects.each do |subject|

--- a/spec/writer_spec.rb
+++ b/spec/writer_spec.rb
@@ -620,6 +620,18 @@ describe "RDF::RDFXML::Writer" do
         parse(serialize).should be_equivalent_graph(@graph, :trace => @debug.join("\n"))
       end
     end
+
+    describe "with a stylesheet" do
+      subject do
+        @graph << [RDF::URI.new("http://release/a"), FOO.ref, RDF::URI.new("http://release/b")]
+        serialize(:stylesheet => "/path/to/rdfxml.xsl")
+      end
+
+      it "should have a stylesheet as a processing instruction in the second line of the XML" do
+        lines = subject.split(/[\r\n]+/)
+        lines[1].should == '<?xml-stylesheet type="text/xsl" href="/path/to/rdfxml.xsl"?>'
+      end
+    end
   
     describe "illegal RDF values" do
       it "raises error with literal as subject" do


### PR DESCRIPTION
Added :stylesheet option to RDF::RDFXML::Writer to allow writing of an XSL stylesheet processing instruction.

I am going to use this to make RDF/XML look a little bit prettier (syntax colouring) in the browser.
